### PR TITLE
Some small, simple fixes.

### DIFF
--- a/migrations/2021/05/Version20210526215941.php
+++ b/migrations/2021/05/Version20210526215941.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210526215941 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book ADD notes LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE holding ADD notes LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE inventory ADD notes LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book DROP notes');
+        $this->addSql('ALTER TABLE holding DROP notes');
+        $this->addSql('ALTER TABLE inventory DROP notes');
+    }
+}

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -25,6 +25,7 @@ class Book extends AbstractEntity implements LinkableInterface {
     use LinkableTrait {
         LinkableTrait::__construct as linkable_construct;
     }
+    use NotesTrait;
 
     /**
      * @var string

--- a/src/Entity/Holding.php
+++ b/src/Entity/Holding.php
@@ -24,6 +24,7 @@ class Holding extends AbstractEntity implements ImageContainerInterface {
         ImageContainerTrait::__construct as protected trait_constructor;
     }
     use DatedTrait;
+    use NotesTrait;
 
     /**
      * @var string

--- a/src/Entity/Inventory.php
+++ b/src/Entity/Inventory.php
@@ -21,6 +21,7 @@ use Nines\UtilBundle\Entity\AbstractEntity;
  */
 class Inventory extends AbstractEntity {
     use DatedTrait;
+    use NotesTrait;
 
     /**
      * @var string

--- a/src/Entity/NotesTrait.php
+++ b/src/Entity/NotesTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace App\Entity;
+
+
+trait NotesTrait {
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $notes;
+
+    /**
+     * @return string|null
+     */
+    public function getNotes() : ?string {
+        return $this->notes;
+    }
+
+    /**
+     * @param string|null $notes
+     *
+     * @return $this
+     */
+    public function setNotes(?string $notes) : self {
+        $this->notes = $notes;
+
+        return $this;
+    }
+
+}

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -22,6 +22,7 @@ use Nines\UtilBundle\Entity\AbstractEntity;
  */
 class Transaction extends AbstractEntity {
     use DatedTrait;
+    use NotesTrait;
 
     /**
      * Price of the transaction in pennies.
@@ -70,12 +71,6 @@ class Transaction extends AbstractEntity {
      * @ORM\Column(type="text", nullable=true)
      */
     private $description;
-
-    /**
-     * @var string
-     * @ORM\Column(type="text", nullable=true)
-     */
-    private $notes;
 
     /**
      * @var Book[]|Collection
@@ -263,16 +258,6 @@ class Transaction extends AbstractEntity {
 
     public function setLocation(?string $location) : self {
         $this->location = $location;
-
-        return $this;
-    }
-
-    public function getNotes() : ?string {
-        return $this->notes;
-    }
-
-    public function setNotes(?string $notes) : self {
-        $this->notes = $notes;
 
         return $this;
     }

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -120,7 +120,7 @@ class Transaction extends AbstractEntity {
      * {@inheritdoc}
      */
     public function __toString() : string {
-        return 'Transaction ' . $this->id;
+        return sprintf('%05d', $this->id);
     }
 
     public function getValue($format = false, $list = false) {

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -12,6 +12,7 @@ namespace App\Form;
 
 use App\Entity\Book;
 use App\Entity\Format;
+use App\Form\Partial\NotesType;
 use Nines\MediaBundle\Form\LinkableType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -86,10 +87,11 @@ class BookType extends AbstractType {
             'label' => 'Description',
             'required' => false,
             'attr' => [
-                'help_block' => '',
+                'help_block' => 'Public description of the item.',
                 'class' => 'tinymce',
             ],
         ]);
+        NotesType::add($builder, $options);
 
         $builder->add('format', Select2EntityType::class, [
             'label' => 'Format',

--- a/src/Form/HoldingType.php
+++ b/src/Form/HoldingType.php
@@ -14,6 +14,7 @@ use App\Entity\Archive;
 use App\Entity\Book;
     use App\Entity\Holding;
     use App\Entity\Parish;
+use App\Form\Partial\NotesType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -71,6 +72,7 @@ class HoldingType extends AbstractType {
                 'class' => 'tinymce',
             ],
         ]);
+        NotesType::add($builder, $options);
         DatedType::buildForm($builder, $options);
     }
 

--- a/src/Form/InventoryType.php
+++ b/src/Form/InventoryType.php
@@ -14,6 +14,7 @@ use App\Entity\Book;
 use App\Entity\Inventory;
 use App\Entity\Parish;
 use App\Entity\Source;
+use App\Form\Partial\NotesType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -89,6 +90,7 @@ class InventoryType extends AbstractType {
                 'class' => 'tinymce',
             ],
         ]);
+        NotesType::add($builder, $options);
     }
 
     /**

--- a/src/Form/Partial/NotesType.php
+++ b/src/Form/Partial/NotesType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Form\Partial;
+
+use App\Entity\Archdeaconry;
+use App\Entity\Diocese;
+use Nines\MediaBundle\Form\LinkableType;
+use Nines\UtilBundle\Form\TermType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Tetranz\Select2EntityBundle\Form\Type\Select2EntityType;
+
+/**
+ * Archdeaconry form.
+ */
+class NotesType extends TermType {
+    /**
+     * Add form fields to $builder.
+     */
+    public static function add(FormBuilderInterface $builder, array $options) : void {
+        $builder->add('notes', TextareaType::class, [
+            'label' => 'Notes',
+            'required' => false,
+            'attr' => [
+                'help_block' => 'Private notes about the item. Never shown to the public.',
+                'class' => 'tinymce',
+            ],
+        ]);
+    }
+
+}

--- a/src/Form/TransactionType.php
+++ b/src/Form/TransactionType.php
@@ -106,15 +106,7 @@ class TransactionType extends AbstractType {
                 'class' => 'tinymce',
             ],
         ]);
-
-        $builder->add('notes', TextareaType::class, [
-            'label' => 'Notes',
-            'required' => false,
-            'attr' => [
-                'help_block' => 'Any additional notes about the transcription',
-                'class' => 'tinymce',
-            ],
-        ]);
+        NotesType::add($builder, $options);
 
         $builder->add('books', Select2EntityType::class, [
             'label' => 'Books',

--- a/templates/book/partial/detail.html.twig
+++ b/templates/book/partial/detail.html.twig
@@ -44,7 +44,7 @@
                 {{ book.description|raw }}
             </td>
         </tr>
-
+        {% include 'partial/notes.html.twig' with {'item': book} %}
         <tr>
             <th>Format</th>
             <td>

--- a/templates/holding/partial/detail.html.twig
+++ b/templates/holding/partial/detail.html.twig
@@ -6,6 +6,7 @@
                 {{ holding.description|raw }}
             </td>
         </tr>
+        {% include 'partial/notes.html.twig' with {'item': holding} %}
         <tr>
             <th>Start Date</th>
             <td>

--- a/templates/inventory/partial/detail.html.twig
+++ b/templates/inventory/partial/detail.html.twig
@@ -12,12 +12,7 @@
                 {{ inventory.modifications|raw }}
             </td>
         </tr>
-        <tr>
-            <th>Notes</th>
-            <td>
-                {{ inventory.description|raw }}
-            </td>
-        </tr>
+        {% include 'partial/notes.html.twig' with {'item': inventory} %}
         <tr>
             <th>Start Date</th>
             <td>

--- a/templates/partial/notes.html.twig
+++ b/templates/partial/notes.html.twig
@@ -1,0 +1,11 @@
+{% if is_granted('ROLE_USER') %}
+    <tr>
+        <th>Notes</th>
+        <td>
+            {% if item.notes %}
+                {{ item.notes|raw }}
+                <p class='text-muted'><i>These notes are not shown to the public.</i></p>
+            {% endif %}
+        </td>
+    </tr>
+{% endif %}

--- a/templates/transaction/partial/detail.html.twig
+++ b/templates/transaction/partial/detail.html.twig
@@ -1,6 +1,12 @@
 <table class='table table-bordered table-condensed table-hover table-striped'>
     <tbody>
         <tr>
+            <th>ID</th>
+            <td>
+                {{ transaction }}
+            </td>
+        </tr>
+        <tr>
             <th>Value</th>
             <td>
                 {{ transaction.value(true) }}

--- a/templates/transaction/partial/detail.html.twig
+++ b/templates/transaction/partial/detail.html.twig
@@ -46,12 +46,7 @@
                 {{ transaction.description|raw }}
             </td>
         </tr>
-        <tr>
-            <th>Notes</th>
-            <td>
-                {{ transaction.notes|raw }}
-            </td>
-        </tr>
+        {% include 'partial/notes.html.twig' with {'item': transaction} %}
         <tr>
             <th>Books</th>
             <td>

--- a/templates/transaction/partial/table.html.twig
+++ b/templates/transaction/partial/table.html.twig
@@ -1,6 +1,7 @@
 <table class="table table-bordered table-condensed table-hover table-striped">
     <thead>
         <tr>
+            <th>ID</th>
             <th>Date</th>
             <th>Value</th>
             <th>Books</th>
@@ -12,6 +13,11 @@
     <tbody>
         {% for transaction in transactions %}
             <tr>
+                <td>
+                    <a href="{{ path('transaction_show', { 'id': transaction.id }) }}">
+                        {{ transaction }}
+                    </a>
+                </td>
                 <td>
                     <a href="{{ path('transaction_show', { 'id': transaction.id }) }}">
                         {% include 'partial/short-date.html.twig' with {'entity': transaction} %}


### PR DESCRIPTION
Create fields for notes. Adds a private notes field to book and
holding. Makes the notes field private for transactions and
inventories.

Make transaction IDs visible and five digits long.

fixes sfu-dhil/bep#62
fixes sfu-dhil/bep#63