### PR TITLE
Address some issues/requests

### DIFF
--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -15,6 +15,7 @@ services:
     test.App\Repository\HoldingRepository: '@App\Repository\HoldingRepository'
     test.App\Repository\InjunctionRepository: '@App\Repository\InjunctionRepository'
     test.App\Repository\InventoryRepository: '@App\Repository\InventoryRepository'
+    test.App\Repository\MonarchRepository: '@App\Repository\MonarchRepository'
     test.App\Repository\NationRepository: '@App\Repository\NationRepository'
     test.App\Repository\ParishRepository: '@App\Repository\ParishRepository'
     test.App\Repository\ProvinceRepository: '@App\Repository\ProvinceRepository'

--- a/migrations/2021/07/Version20210722171202.php
+++ b/migrations/2021/07/Version20210722171202.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210722171202 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX book_ft ON book');
+        $this->addSql('ALTER TABLE book ADD variant_imprint LONGTEXT DEFAULT NULL, CHANGE publisher imprint LONGTEXT DEFAULT NULL');
+        $this->addSql('CREATE FULLTEXT INDEX book_ft ON book (title, uniform_title, variant_titles, description, author, imprint, variant_imprint, notes)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX book_ft ON book');
+        $this->addSql('ALTER TABLE book ADD publisher LONGTEXT CHARACTER SET utf8mb4 DEFAULT NULL COLLATE `utf8mb4_unicode_ci`, DROP imprint, DROP variant_imprint');
+        $this->addSql('CREATE FULLTEXT INDEX book_ft ON book (title, uniform_title, variant_titles, description, author, publisher, notes)');
+    }
+}

--- a/migrations/2021/07/Version20210722174620.php
+++ b/migrations/2021/07/Version20210722174620.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210722174620 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE monarch (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(120) NOT NULL, label VARCHAR(120) NOT NULL, description LONGTEXT DEFAULT NULL, created DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', FULLTEXT INDEX IDX_71FB7BAEEA750E8 (label), FULLTEXT INDEX IDX_71FB7BAE6DE44026 (description), FULLTEXT INDEX IDX_71FB7BAEEA750E86DE44026 (label, description), UNIQUE INDEX UNIQ_71FB7BAE5E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE inventory ADD monarch_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE inventory ADD CONSTRAINT FK_B12D4A3653033E82 FOREIGN KEY (monarch_id) REFERENCES monarch (id)');
+        $this->addSql('CREATE INDEX IDX_B12D4A3653033E82 ON inventory (monarch_id)');
+        $this->addSql('ALTER TABLE transact ADD monarch_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE transact ADD CONSTRAINT FK_FA42B7F653033E82 FOREIGN KEY (monarch_id) REFERENCES monarch (id)');
+        $this->addSql('CREATE INDEX IDX_FA42B7F653033E82 ON transact (monarch_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE inventory DROP FOREIGN KEY FK_B12D4A3653033E82');
+        $this->addSql('ALTER TABLE transact DROP FOREIGN KEY FK_FA42B7F653033E82');
+        $this->addSql('DROP TABLE monarch');
+        $this->addSql('DROP INDEX IDX_B12D4A3653033E82 ON inventory');
+        $this->addSql('ALTER TABLE inventory DROP monarch_id');
+        $this->addSql('DROP INDEX IDX_FA42B7F653033E82 ON transact');
+        $this->addSql('ALTER TABLE transact DROP monarch_id');
+    }
+}

--- a/migrations/2021/07/Version20210722181729.php
+++ b/migrations/2021/07/Version20210722181729.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210722181729 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE inventory ADD page_number INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE inventory DROP page_number');
+    }
+}

--- a/src/Controller/BookController.php
+++ b/src/Controller/BookController.php
@@ -74,7 +74,7 @@ class BookController extends AbstractController implements PaginatorAwareInterfa
      */
     public function typeahead(Request $request, BookRepository $bookRepository) {
         $q = $request->query->get('q');
-        if ( ! $q) {
+        if ( (! $q) || (mb_strlen($q) < 4)) {
             return new JsonResponse([]);
         }
         $data = [];
@@ -82,7 +82,7 @@ class BookController extends AbstractController implements PaginatorAwareInterfa
         foreach ($bookRepository->typeaheadQuery($q) as $result) {
             $data[] = [
                 'id' => $result->getId(),
-                'text' => (string) $result,
+                'text' => implode(", ", array_map(fn($s) => '"' . $s . '"', array_merge([$result->getTitle()], $result->getVariantTitles()))),
             ];
         }
 

--- a/src/Controller/MonarchController.php
+++ b/src/Controller/MonarchController.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Controller;
+
+use App\Entity\Monarch;
+use App\Form\MonarchType;
+use App\Repository\MonarchRepository;
+
+use Knp\Bundle\PaginatorBundle\Definition\PaginatorAwareInterface;
+use Nines\UtilBundle\Controller\PaginatorTrait;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/monarch")
+ */
+class MonarchController extends AbstractController implements PaginatorAwareInterface {
+    use PaginatorTrait;
+
+    /**
+     * @Route("/", name="monarch_index", methods={"GET"})
+     *
+     * @Template
+     */
+    public function index(Request $request, MonarchRepository $monarchRepository) : array {
+        $query = $monarchRepository->indexQuery();
+        $pageSize = (int) $this->getParameter('page_size');
+        $page = $request->query->getint('page', 1);
+
+        return [
+            'monarchs' => $this->paginator->paginate($query, $page, $pageSize),
+        ];
+    }
+
+    /**
+     * @Route("/search", name="monarch_search", methods={"GET"})
+     *
+     * @Template
+     *
+     * @return array
+     */
+    public function search(Request $request, MonarchRepository $monarchRepository) {
+        $q = $request->query->get('q');
+        if ($q) {
+            $query = $monarchRepository->searchQuery($q);
+            $monarchs = $this->paginator->paginate($query, $request->query->getInt('page', 1), $this->getParameter('page_size'), ['wrap-queries' => true]);
+        } else {
+            $monarchs = [];
+        }
+
+        return [
+            'monarchs' => $monarchs,
+            'q' => $q,
+        ];
+    }
+
+    /**
+     * @Route("/typeahead", name="monarch_typeahead", methods={"GET"})
+     *
+     * @return JsonResponse
+     */
+    public function typeahead(Request $request, MonarchRepository $monarchRepository) {
+        $q = $request->query->get('q');
+        if ( ! $q) {
+            return new JsonResponse([]);
+        }
+        $data = [];
+        foreach ($monarchRepository->typeaheadQuery($q) as $result) {
+            $data[] = [
+                'id' => $result->getId(),
+                'text' => (string) $result,
+            ];
+        }
+
+        return new JsonResponse($data);
+    }
+
+    /**
+     * @Route("/new", name="monarch_new", methods={"GET", "POST"})
+     * @Template
+     * @IsGranted("ROLE_CONTENT_ADMIN")
+     *
+     * @return array|RedirectResponse
+     */
+    public function new(Request $request) {
+        $monarch = new Monarch();
+        $form = $this->createForm(MonarchType::class, $monarch);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager = $this->getDoctrine()->getManager();
+            $entityManager->persist($monarch);
+            $entityManager->flush();
+            $this->addFlash('success', 'The new monarch has been saved.');
+
+            return $this->redirectToRoute('monarch_show', ['id' => $monarch->getId()]);
+        }
+
+        return [
+            'monarch' => $monarch,
+            'form' => $form->createView(),
+        ];
+    }
+
+    /**
+     * @Route("/new_popup", name="monarch_new_popup", methods={"GET", "POST"})
+     * @Template
+     * @IsGranted("ROLE_CONTENT_ADMIN")
+     *
+     * @return array|RedirectResponse
+     */
+    public function new_popup(Request $request) {
+        return $this->new($request);
+    }
+
+    /**
+     * @Route("/{id}", name="monarch_show", methods={"GET"})
+     * @Template
+     *
+     * @return array
+     */
+    public function show(Monarch $monarch) {
+        return [
+            'monarch' => $monarch,
+        ];
+    }
+
+    /**
+     * @IsGranted("ROLE_CONTENT_ADMIN")
+     * @Route("/{id}/edit", name="monarch_edit", methods={"GET", "POST"})
+     *
+     * @Template
+     *
+     * @return array|RedirectResponse
+     */
+    public function edit(Request $request, Monarch $monarch) {
+        $form = $this->createForm(MonarchType::class, $monarch);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->getDoctrine()->getManager()->flush();
+            $this->addFlash('success', 'The updated monarch has been saved.');
+
+            return $this->redirectToRoute('monarch_show', ['id' => $monarch->getId()]);
+        }
+
+        return [
+            'monarch' => $monarch,
+            'form' => $form->createView(),
+        ];
+    }
+
+    /**
+     * @IsGranted("ROLE_CONTENT_ADMIN")
+     * @Route("/{id}", name="monarch_delete", methods={"DELETE"})
+     *
+     * @return RedirectResponse
+     */
+    public function delete(Request $request, Monarch $monarch) {
+        if ($this->isCsrfTokenValid('delete' . $monarch->getId(), $request->request->get('_token'))) {
+            $entityManager = $this->getDoctrine()->getManager();
+            $entityManager->remove($monarch);
+            $entityManager->flush();
+            $this->addFlash('success', 'The monarch has been deleted.');
+        }
+
+        return $this->redirectToRoute('monarch_index');
+    }
+}

--- a/src/DataFixtures/BookFixtures.php
+++ b/src/DataFixtures/BookFixtures.php
@@ -26,7 +26,7 @@ class BookFixtures extends Fixture implements DependentFixtureInterface {
             $fixture->setUniformTitle("This is paragraph {$i}");
             $fixture->setVariantTitles(['VariantTitles ' . $i]);
             $fixture->setAuthor('Author ' . $i);
-            $fixture->setPublisher('Publisher ' . $i);
+            $fixture->setImprint('Imprint ' . $i);
             $fixture->setDate('Date ' . $i);
             $fixture->setDescription("<p>This is paragraph {$i}</p>");
             $fixture->setFormat($this->getReference('format.' . $i));

--- a/src/DataFixtures/MonarchFixtures.php
+++ b/src/DataFixtures/MonarchFixtures.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\DataFixtures;
+
+use App\Entity\Monarch;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+
+class MonarchFixtures extends Fixture {
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ObjectManager $em) : void {
+        for ($i = 1; $i <= 4; $i++) {
+            $fixture = new Monarch();
+            $fixture->setName('Name ' . $i);
+            $fixture->setLabel('Label ' . $i);
+            $fixture->setDescription("<p>This is paragraph {$i}</p>");
+            $em->persist($fixture);
+            $this->setReference('monarch.' . $i, $fixture);
+        }
+        $em->flush();
+    }
+}

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -21,7 +21,7 @@ use Nines\UtilBundle\Entity\AbstractEntity;
 /**
  * @ORM\Entity(repositoryClass=BookRepository::class)
  * @ORM\Table(indexes={
- *     @ORM\Index(name="book_ft", columns={"title", "uniform_title", "variant_titles", "description", "author", "publisher", "notes"}, flags={"fulltext"})
+ *     @ORM\Index(name="book_ft", columns={"title", "uniform_title", "variant_titles", "description", "author", "imprint", "variant_imprint", "notes"}, flags={"fulltext"})
  * })
  */
 class Book extends AbstractEntity implements LinkableInterface {
@@ -58,7 +58,13 @@ class Book extends AbstractEntity implements LinkableInterface {
      * @var string
      * @ORM\Column(type="text", nullable=true)
      */
-    private $publisher;
+    private $imprint;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $variantImprint;
 
     /**
      * @var string
@@ -227,12 +233,12 @@ class Book extends AbstractEntity implements LinkableInterface {
         return $this;
     }
 
-    public function getPublisher() : ?string {
-        return $this->publisher;
+    public function getImprint() : ?string {
+        return $this->imprint;
     }
 
-    public function setPublisher(?string $publisher) : self {
-        $this->publisher = $publisher;
+    public function setImprint(?string $imprint) : self {
+        $this->imprint = $imprint;
 
         return $this;
     }
@@ -287,6 +293,18 @@ class Book extends AbstractEntity implements LinkableInterface {
                 $holding->setBook(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getVariantImprint(): ?string
+    {
+        return $this->variantImprint;
+    }
+
+    public function setVariantImprint(?string $variantImprint): self
+    {
+        $this->variantImprint = $variantImprint;
 
         return $this;
     }

--- a/src/Entity/Inventory.php
+++ b/src/Entity/Inventory.php
@@ -62,6 +62,13 @@ class Inventory extends AbstractEntity implements ImageContainerInterface {
     private $parish;
 
     /**
+     * @var Monarch
+     * @ORM\ManyToOne(targetEntity="Monarch", inversedBy="inventories")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $monarch;
+
+    /**
      * @var Book[]|Collection
      * @ORM\ManyToMany(targetEntity="App\Entity\Book", inversedBy="inventories")
      */
@@ -146,6 +153,16 @@ class Inventory extends AbstractEntity implements ImageContainerInterface {
 
     public function removeBook(Book $book) : self {
         $this->books->removeElement($book);
+
+        return $this;
+    }
+
+    public function getMonarch() : ?Monarch {
+        return $this->monarch;
+    }
+
+    public function setMonarch(?Monarch $monarch) : self {
+        $this->monarch = $monarch;
 
         return $this;
     }

--- a/src/Entity/Inventory.php
+++ b/src/Entity/Inventory.php
@@ -30,6 +30,12 @@ class Inventory extends AbstractEntity implements ImageContainerInterface {
     use ImageContainerTrait;
 
     /**
+     * @var int
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $pageNumber;
+
+    /**
      * @var string
      * @ORM\Column(type="text")
      */
@@ -163,6 +169,18 @@ class Inventory extends AbstractEntity implements ImageContainerInterface {
 
     public function setMonarch(?Monarch $monarch) : self {
         $this->monarch = $monarch;
+
+        return $this;
+    }
+
+    public function getPageNumber(): ?int
+    {
+        return $this->pageNumber;
+    }
+
+    public function setPageNumber(?int $pageNumber): self
+    {
+        $this->pageNumber = $pageNumber;
 
         return $this;
     }

--- a/src/Entity/Monarch.php
+++ b/src/Entity/Monarch.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Entity;
+
+use App\Repository\MonarchRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Nines\UtilBundle\Entity\AbstractTerm;
+
+/**
+ * @ORM\Entity(repositoryClass=MonarchRepository::class)
+ */
+class Monarch extends AbstractTerm {
+    /**
+     * @var Collection
+     * @ORM\OneToMany(targetEntity="Transaction", mappedBy="monarch")
+     */
+    private $transactions;
+
+    /**
+     * @var Collection
+     * @ORM\OneToMany(targetEntity="Inventory", mappedBy="monarch")
+     */
+    private $inventories;
+
+    public function __construct() {
+        parent::__construct();
+        $this->transactions = new ArrayCollection();
+        $this->inventories = new ArrayCollection();
+    }
+
+    /**
+     * @return Collection|transaction[]
+     */
+    public function getTransactions() : Collection {
+        return $this->transactions;
+    }
+
+    public function addTransaction(transaction $transaction) : self {
+        if ( ! $this->transactions->contains($transaction)) {
+            $this->transactions[] = $transaction;
+            $transaction->setMonarch($this);
+        }
+
+        return $this;
+    }
+
+    public function removeTransaction(transaction $transaction) : self {
+        if ($this->transactions->removeElement($transaction)) {
+            // set the owning side to null (unless already changed)
+            if ($transaction->getMonarch() === $this) {
+                $transaction->setMonarch(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|inventory[]
+     */
+    public function getInventories() : Collection {
+        return $this->inventories;
+    }
+
+    public function addInventory(inventory $inventory) : self {
+        if ( ! $this->inventories->contains($inventory)) {
+            $this->inventories[] = $inventory;
+            $inventory->setMonarch($this);
+        }
+
+        return $this;
+    }
+
+    public function removeInventory(inventory $inventory) : self {
+        if ($this->inventories->removeElement($inventory)) {
+            // set the owning side to null (unless already changed)
+            if ($inventory->getMonarch() === $this) {
+                $inventory->setMonarch(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -107,6 +107,13 @@ class Transaction extends AbstractEntity {
      */
     private $injunction;
 
+    /**
+     * @var Monarch
+     * @ORM\ManyToOne(targetEntity="Monarch", inversedBy="inventories")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $monarch;
+
     public function __construct() {
         parent::__construct();
         $this->copies = 1;
@@ -303,6 +310,16 @@ class Transaction extends AbstractEntity {
 
     public function removeTransactionCategory(TransactionCategory $transactionCategory) : self {
         $this->transactionCategories->removeElement($transactionCategory);
+
+        return $this;
+    }
+
+    public function getMonarch() : ?Monarch {
+        return $this->monarch;
+    }
+
+    public function setMonarch(?Monarch $monarch) : self {
+        $this->monarch = $monarch;
 
         return $this;
     }

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -69,11 +69,18 @@ class BookType extends AbstractType {
                 'help_block' => '',
             ],
         ]);
-        $builder->add('publisher', TextareaType::class, [
-            'label' => 'Publisher',
+        $builder->add('imprint', TextareaType::class, [
+            'label' => 'Imprint',
             'required' => false,
             'attr' => [
-                'help_block' => '',
+                'help_block' => 'A modern spelling imprint',
+            ],
+        ]);
+        $builder->add('variantImprint', TextareaType::class, [
+            'label' => 'Variant Imprint',
+            'required' => false,
+            'attr' => [
+                'help_block' => 'Original spelling imprint and any variations of it',
             ],
         ]);
         $builder->add('date', TextType::class, [

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -34,7 +34,7 @@ class BookType extends AbstractType {
             'label' => 'Title',
             'required' => false,
             'attr' => [
-                'help_block' => 'A modern-spelling title',
+                'help_block' => 'As it appears in the ESTC',
                 'class' => '',
             ],
         ]);
@@ -59,7 +59,7 @@ class BookType extends AbstractType {
 
             'attr' => [
                 'class' => 'collection collection-simple',
-                'help_block' => 'Original spelling title and any variants of it',
+                'help_block' => "Year, followed by the title in modern English. Eg. '1631, A thanksgiving, and prayer for the safe child bearing of the queen's majesty'. Also add any other variant titles listed in the ESTC.",
             ],
         ]);
         $builder->add('author', TextType::class, [

--- a/src/Form/InventoryType.php
+++ b/src/Form/InventoryType.php
@@ -12,6 +12,7 @@ namespace App\Form;
 
 use App\Entity\Book;
 use App\Entity\Inventory;
+use App\Entity\Monarch;
 use App\Entity\Parish;
 use App\Entity\Source;
 use App\Form\Partial\DatedType;
@@ -50,6 +51,18 @@ class InventoryType extends AbstractType {
                 'help_block' => '',
                 'add_path' => 'source_new_popup',
                 'add_label' => 'Add Source',
+            ],
+        ]);
+
+        $builder->add('monarch', Select2EntityType::class, [
+            'label' => 'Monarch',
+            'required' => false,
+            'class' => Monarch::class,
+            'remote_route' => 'monarch_typeahead',
+            'attr' => [
+                'help_block' => '',
+                'add_path' => 'monarch_new_popup',
+                'add_label' => 'Add Monarch',
             ],
         ]);
 

--- a/src/Form/InventoryType.php
+++ b/src/Form/InventoryType.php
@@ -18,6 +18,7 @@ use App\Entity\Source;
 use App\Form\Partial\DatedType;
 use App\Form\Partial\NotesType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -51,6 +52,14 @@ class InventoryType extends AbstractType {
                 'help_block' => '',
                 'add_path' => 'source_new_popup',
                 'add_label' => 'Add Source',
+            ],
+        ]);
+
+        $builder->add('pageNumber', IntegerType::class, [
+            'label' => 'pageNumber',
+            'required' => false,
+            'attr' => [
+                'help_block' => '',
             ],
         ]);
 

--- a/src/Form/MonarchType.php
+++ b/src/Form/MonarchType.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Form;
+
+use App\Entity\Monarch;
+
+use Nines\UtilBundle\Form\TermType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Monarch form.
+ */
+class MonarchType extends TermType {
+    /**
+     * Add form fields to $builder.
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options) : void {
+        parent::buildForm($builder, $options);
+    }
+
+    /**
+     * Define options for the form.
+     *
+     * Set default, optional, and required options passed to the
+     * buildForm() method via the $options parameter.
+     */
+    public function configureOptions(OptionsResolver $resolver) : void {
+        $resolver->setDefaults([
+            'data_class' => Monarch::class,
+        ]);
+    }
+}

--- a/src/Form/TransactionType.php
+++ b/src/Form/TransactionType.php
@@ -12,10 +12,12 @@ namespace App\Form;
 
 use App\Entity\Book;
 use App\Entity\Injunction;
+use App\Entity\Monarch;
 use App\Entity\Parish;
 use App\Entity\Source;
 use App\Entity\Transaction;
 use App\Entity\TransactionCategory;
+use App\Form\Mapper\LsdMapper;
 use App\Form\Partial\DatedType;
 use App\Form\Partial\NotesType;
 use Doctrine\ORM\EntityRepository;
@@ -182,7 +184,19 @@ class TransactionType extends AbstractType {
             ],
         ]);
 
-        $builder->setDataMapper(new Mapper\LsdMapper());
+        $builder->add('monarch', Select2EntityType::class, [
+            'label' => 'Monarch',
+            'required' => false,
+            'class' => Monarch::class,
+            'remote_route' => 'monarch_typeahead',
+            'attr' => [
+                'help_block' => '',
+                'add_path' => 'monarch_new_popup',
+                'add_label' => 'Add Monarch',
+            ],
+        ]);
+
+        $builder->setDataMapper(new LsdMapper());
     }
 
     /**

--- a/src/Form/TransactionType.php
+++ b/src/Form/TransactionType.php
@@ -90,7 +90,7 @@ class TransactionType extends AbstractType {
             'label' => 'Location',
             'required' => false,
             'attr' => [
-                'help_block' => 'Enter the location of the transaction, if known. Optionally include details of the location in the Description field.',
+                'help_block' => 'Enter the location or parish if it is different from the parish you are working on. For example, if a book was purchased in Oxford for a London parish, enter “Oxford” or “Oxford, All Saints.”',
             ],
         ]);
 

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -79,6 +79,7 @@ class Builder implements ContainerAwareInterface {
         $browse->addChild('Dioceses', ['route' => 'diocese_index']);
         $browse->addChild('Injunctions', ['route' => 'injunction_index']);
         $browse->addChild('Inventories', ['route' => 'inventory_index']);
+        $browse->addChild('Monarchs', ['route' => 'monarch_index']);
         $browse->addChild('Nations', ['route' => 'nation_index']);
         $browse->addChild('Parishes', ['route' => 'parish_index']);
         $browse->addChild('Provinces', ['route' => 'province_index']);

--- a/src/Repository/BookRepository.php
+++ b/src/Repository/BookRepository.php
@@ -45,10 +45,11 @@ class BookRepository extends ServiceEntityRepository {
      */
     public function typeaheadQuery($q) {
         $qb = $this->createQueryBuilder('book');
-        $qb->andWhere('book.title LIKE :q');
-        $qb->orderBy('book.title');
+        $qb->where('book.title LIKE :q');
+        $qb->orWhere('book.variantTitles LIKE :q');
+        $qb->orderBy('book.variantTitles');
         $qb->addOrderBy('book.id');
-        $qb->setParameter('q', "{$q}%");
+        $qb->setParameter('q', "%{$q}%");
 
         return $qb->getQuery()->execute();
     }

--- a/src/Repository/BookRepository.php
+++ b/src/Repository/BookRepository.php
@@ -60,7 +60,7 @@ class BookRepository extends ServiceEntityRepository {
      */
     public function searchQuery($q) {
         $qb = $this->createQueryBuilder('book');
-        $qb->addSelect('MATCH (book.title, book.uniformTitle, book.variantTitles, book.description, book.author, book.publisher, book.notes) AGAINST(:q BOOLEAN) as HIDDEN score');
+        $qb->addSelect('MATCH (book.title, book.uniformTitle, book.variantTitles, book.description, book.author, book.imprint, book.variantImprint, book.notes) AGAINST(:q BOOLEAN) as HIDDEN score');
         $qb->andHaving('score > 0');
         $qb->orderBy('score', 'DESC');
         $qb->setParameter('q', $q);

--- a/src/Repository/MonarchRepository.php
+++ b/src/Repository/MonarchRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Monarch;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Query;
+use Doctrine\Persistence\ManagerRegistry;
+use Nines\UtilBundle\Repository\TermRepository;
+
+/**
+ * @method Monarch|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Monarch|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Monarch[]    findAll()
+ * @method Monarch[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class MonarchRepository extends TermRepository {
+    public function __construct(ManagerRegistry $registry) {
+        parent::__construct($registry, Monarch::class);
+    }
+}

--- a/templates/book/partial/detail.html.twig
+++ b/templates/book/partial/detail.html.twig
@@ -27,9 +27,15 @@
             </td>
         </tr>
         <tr>
-            <th>Publisher</th>
+            <th>Imprint</th>
             <td>
-                {{ book.publisher }}
+                {{ book.imprint }}
+            </td>
+        </tr>
+        <tr>
+            <th>Variant Imprint</th>
+            <td>
+                {{ book.variantImprint }}
             </td>
         </tr>
         <tr>

--- a/templates/book/partial/table.html.twig
+++ b/templates/book/partial/table.html.twig
@@ -4,7 +4,7 @@
             <th>Title</th>
             <th>Uniform Title</th>
             <th>Author</th>
-            <th>Publisher</th>
+            <th>Imprint</th>
             <th>Date</th>
         </tr>
     </thead>
@@ -25,7 +25,7 @@
                 </td>
 
                 <td>
-                    {{ book.publisher }}
+                    {{ book.imprint }}
                 </td>
 
                 <td>

--- a/templates/inventory/partial/detail.html.twig
+++ b/templates/inventory/partial/detail.html.twig
@@ -20,7 +20,11 @@
         </tr>
 
         {% include 'partial/notes.html.twig' with {'item': inventory} %}
-        {% include 'partial/long-date.html.twig' with {'entity': inventory} %}
+
+        <tr>
+            <th>Date</th>
+            <td>{% include 'partial/long-date.html.twig' with {'entity': inventory} %}</td>
+        </tr>
 
         <tr>
             <th>Source</th>
@@ -29,6 +33,10 @@
                     <a href='{{ path("source_show", {"id": inventory.source.id}) }}'>{{ inventory.source }}</a>
                 {% endif %}
             </td>
+        </tr>
+        <tr>
+            <th>Page Number</th>
+            <td>{{ inventory.pageNumber }}</td>
         </tr>
         <tr>
             <th>Parish</th>

--- a/templates/monarch/edit.html.twig
+++ b/templates/monarch/edit.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+    {% block title %}Edit Monarch {% endblock %}
+
+    {% block body %}
+        <h1>Edit Monarch</h1>
+
+        {% embed 'monarch/partial/form.html.twig' %}
+        {% endembed %}
+
+    {% endblock %}
+
+    {% block javascripts %}
+        {% include '@NinesEditor/editor/widget.html.twig' %}
+    {% endblock %}

--- a/templates/monarch/index.html.twig
+++ b/templates/monarch/index.html.twig
@@ -1,0 +1,33 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Monarch List{% endblock %}
+
+{% block pageheader %}
+    <h1>Monarch List</h1>
+    <p class="count">
+        Displaying {{ monarchs|length }} Monarchs of {{ monarchs.getTotalItemCount }} total.
+    </p>
+{% endblock %}
+
+{% block body %}
+
+    <div class='btn-toolbar pull-right'>
+        <div class='btn-group'>
+            {% if is_granted('ROLE_CONTENT_ADMIN') %}
+                <a href="{{ path('monarch_new') }}" class="btn btn-default">
+                    <span class="glyphicon glyphicon-plus"></span> New </a>
+            {% endif %}
+
+            <a href="{{ path('monarch_search') }}" class="btn btn-default">
+                <span class="glyphicon glyphicon-search"></span> Search </a>
+        </div>
+    </div>
+
+    {% embed 'monarch/partial/table.html.twig' %}
+    {% endembed %}
+
+    <div class="navigation">
+        {{ knp_pagination_render(monarchs) }}
+    </div>
+
+{% endblock %}

--- a/templates/monarch/new.html.twig
+++ b/templates/monarch/new.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+    {% block title %}New Monarch {% endblock %}
+
+    {% block body %}
+        <h1>New Monarch</h1>
+
+        {% embed 'monarch/partial/form.html.twig' %}
+        {% endembed %}
+
+    {% endblock %}
+
+    {% block javascripts %}
+        {% include '@NinesEditor/editor/widget.html.twig' %}
+    {% endblock %}

--- a/templates/monarch/new_popup.html.twig
+++ b/templates/monarch/new_popup.html.twig
@@ -1,0 +1,15 @@
+{% extends 'popup.html.twig' %}
+
+    {% block title %}New Monarch {% endblock %}
+
+    {% block body %}
+        <h1>New Monarch</h1>
+
+        {% embed 'monarch/partial/form.html.twig' %}
+        {% endembed %}
+
+    {% endblock %}
+
+    {% block javascripts %}
+        {% include '@NinesEditor/editor/widget.html.twig' %}
+    {% endblock %}

--- a/templates/monarch/partial/detail.html.twig
+++ b/templates/monarch/partial/detail.html.twig
@@ -1,0 +1,37 @@
+{% embed '@NinesUtil/term/partial/show.html.twig' with {'term': monarch} %}
+    {% block callback %}
+        <tr>
+            <th>Inventories</th>
+            <td>
+                {% if monarch.inventories|length > 0 %}
+                    <ul>
+                        {% for inventory in monarch.inventories %}
+                            <li>
+                                <a href='{{ path("inventory_show", {"id":inventory.id }) }}'>
+                                    {{ inventory }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
+            <th>Transactions</th>
+            <td>
+                {% if monarch.transactions|length > 0 %}
+                    <ul>
+                        {% for transaction in monarch.transactions %}
+                            <li>
+                                <a href='{{ path("transaction_show", {"id":transaction.id }) }}'>
+                                    {{ transaction }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </td>
+        </tr>
+    {% endblock %}
+{% endembed %}
+

--- a/templates/monarch/partial/form.html.twig
+++ b/templates/monarch/partial/form.html.twig
@@ -1,0 +1,15 @@
+{{ form_start(form) }}
+{{ form_widget(form) }}
+<div class="form-group">
+    <div class="col-sm-2"></div>
+    <div class="col-sm-10">
+        <input type="submit" value="Save" class="btn btn-primary" />
+        {% if monarch.id is null %}
+            <a href="{{ path('monarch_index') }}" class="btn btn-warning"> Cancel </a>
+        {% else %}
+            <a href="{{ path('monarch_show', { 'id': monarch.id }) }}" class="btn btn-warning"> Cancel </a>
+        {% endif %}
+    </div>
+</div>
+{{ form_end(form) }}
+

--- a/templates/monarch/partial/table.html.twig
+++ b/templates/monarch/partial/table.html.twig
@@ -1,0 +1,3 @@
+{% embed '@NinesUtil/term/partial/index.html.twig'
+    with {'terms': monarchs, 'path': 'monarch_show' } %}
+{% endembed %}

--- a/templates/monarch/search.html.twig
+++ b/templates/monarch/search.html.twig
@@ -1,0 +1,56 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Monarch Search{% endblock %}
+
+ {% block pageheader %}
+     <h1>Monarch Search</h1>
+     {% if monarchs|length %}
+         <p class="count">
+             Displaying {{ monarchs|length }} Monarchs of {{ monarchs.getTotalItemCount }} total.
+         </p>
+     {% endif %}
+ {% endblock %}
+
+{% block body %}
+
+    <form method="get" action="{{ path('monarch_search') }}" class="form-horizontal">
+        <fieldset>
+            <legend>Search</legend>
+            <div class='form-group'>
+                <label class='col-sm-2 control-label' for='q'>Search term</label>
+                <div class='col-sm-10'>
+                    <div class='input-group'>
+                        <input type='text' name='q' id='q' class='form-control' value='{{ q }}'>
+                        <span class="input-group-btn">
+                            <button class="btn btn-primary" id='btn-search' type="submit">
+                                <span class='glyphicon glyphicon-search'></span>
+                                Search
+                            </button>
+                        </span>
+                    </div>
+                </div>
+            </div>
+            <p> Full text searching options, if available:</p>
+            <ul>
+                <li><code>shakespeare</code> - shakespeare should be present, but might not be</li>
+                <li><code>shakes*</code> - words starting with shakes should be present</li>
+                <li><code>+agnes</code> - agnes must be present</li>
+                <li><code>-fisher</code> - fisher must not be present</li>
+                <li>Combinations are OK: <code>+agnes -fisher</code> finds Anges who isn't a Fisher</li>
+                <li>Phrases are OK: <code>"nee agnes"</code> finds rows that contain the literal phrase.
+            </ul>
+        </fieldset>
+    </form>
+
+    {% if monarchs|length %}
+
+        {% embed 'monarch/partial/table.html.twig' %}
+        {% endembed %}
+
+        <div class="navigation">
+            {{ knp_pagination_render(monarchs) }}
+        </div>
+    {% endif %}
+
+{% endblock %}
+

--- a/templates/monarch/show.html.twig
+++ b/templates/monarch/show.html.twig
@@ -1,0 +1,30 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Monarch Details {% endblock %}
+
+ {% block pageheader %}
+     <h1>Monarch Details</h1>
+ {% endblock %}
+
+{% block body %}
+
+    {% if is_granted('ROLE_CONTENT_ADMIN') %}
+        <div class='btn-toolbar pull-right'>
+            <div class='btn-group'>
+                <a href="{{ path('monarch_edit', {'id': monarch.id }) }}" class="btn btn-default">
+                    <span class="glyphicon glyphicon-edit"></span> Edit </a>
+            </div>
+            <div class='btn-group'>
+                <form class='delete-form' method="post" action="{{ path('monarch_delete', {'id': monarch.id }) }}" onsubmit="return confirm('Are you sure you want to delete this item?');">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <input type="hidden" name="_token" value="{{ csrf_token("delete" ~ monarch.id) }}">
+                    <button class="btn btn-danger"><span class="glyphicon glyphicon-trash"></span> Delete</button>
+                </form>
+            </div>
+        </div>
+    {% endif %}
+
+    {% embed 'monarch/partial/detail.html.twig' %}
+    {% endembed %}
+
+{% endblock %}

--- a/templates/partial/long-date.html.twig
+++ b/templates/partial/long-date.html.twig
@@ -1,5 +1,5 @@
 {% if entity.writtenDate %}
-    Written as "{{ entity.writtenDate }}" <br/>
+    {{ entity.writtenDate }} <br/>
 {% endif %}
 {% if entity.startDate and entity.endDate %}
     Between {{ entity.startDate }} and {{ entity.endDate }}

--- a/tests/Controller/BookTest.php
+++ b/tests/Controller/BookTest.php
@@ -229,7 +229,7 @@ class BookTest extends ControllerBaseCase {
             'book[uniformTitle]' => 'Updated UniformTitle',
             'book[variantTitles][0]' => 'Updated VariantTitles',
             'book[author]' => 'Updated Author',
-            'book[publisher]' => 'Updated Publisher',
+            'book[imprint]' => 'Updated Imprint',
             'book[date]' => 'Updated Date',
             'book[description]' => 'Updated Description',
         ]);
@@ -242,7 +242,7 @@ class BookTest extends ControllerBaseCase {
         $this->assertSame(1, $responseCrawler->filter('td:contains("Updated UniformTitle")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("Updated VariantTitles")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Author")')->count());
-        $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Publisher")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Imprint")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Date")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Description")')->count());
     }
@@ -300,7 +300,7 @@ class BookTest extends ControllerBaseCase {
             'book[title]' => 'New Title',
             'book[uniformTitle]' => 'New UniformTitle',
             'book[author]' => 'New Author',
-            'book[publisher]' => 'New Publisher',
+            'book[imprint]' => 'New Imprint',
             'book[date]' => 'New Date',
             'book[description]' => 'New Description',
         ]);
@@ -313,7 +313,7 @@ class BookTest extends ControllerBaseCase {
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Title")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New UniformTitle")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Author")')->count());
-        $this->assertSame(1, $responseCrawler->filter('td:contains("New Publisher")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Imprint")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Date")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Description")')->count());
     }
@@ -331,7 +331,7 @@ class BookTest extends ControllerBaseCase {
             'book[title]' => 'New Title',
             'book[uniformTitle]' => 'New UniformTitle',
             'book[author]' => 'New Author',
-            'book[publisher]' => 'New Publisher',
+            'book[imprint]' => 'New Imprint',
             'book[date]' => 'New Date',
             'book[description]' => 'New Description',
         ]);
@@ -343,7 +343,7 @@ class BookTest extends ControllerBaseCase {
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Title")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New UniformTitle")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Author")')->count());
-        $this->assertSame(1, $responseCrawler->filter('td:contains("New Publisher")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Imprint")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Date")')->count());
         $this->assertSame(1, $responseCrawler->filter('td:contains("New Description")')->count());
     }

--- a/tests/Controller/MonarchTest.php
+++ b/tests/Controller/MonarchTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * (c) 2021 Michael Joyce <mjoyce@sfu.ca>
+ * This source file is subject to the GPL v2, bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Tests\Controller;
+
+use App\DataFixtures\MonarchFixtures;
+use App\Repository\MonarchRepository;
+use Nines\UserBundle\DataFixtures\UserFixtures;
+use Nines\UtilBundle\Tests\ControllerBaseCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class MonarchTest extends ControllerBaseCase {
+    // Change this to HTTP_OK when the site is public.
+    private const ANON_RESPONSE_CODE = Response::HTTP_FOUND;
+
+    private const TYPEAHEAD_QUERY = 'label';
+
+    protected function fixtures() : array {
+        return [
+            MonarchFixtures::class,
+            UserFixtures::class,
+        ];
+    }
+
+    /**
+     * @group anon
+     * @group index
+     */
+    public function testAnonIndex() : void {
+        $crawler = $this->client->request('GET', '/monarch/');
+        $this->assertSame(self::ANON_RESPONSE_CODE, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(0, $crawler->selectLink('New')->count());
+    }
+
+    /**
+     * @group user
+     * @group index
+     */
+    public function testUserIndex() : void {
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(0, $crawler->selectLink('New')->count());
+    }
+
+    /**
+     * @group admin
+     * @group index
+     */
+    public function testAdminIndex() : void {
+        $this->login('user.admin');
+        $crawler = $this->client->request('GET', '/monarch/');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->selectLink('New')->count());
+    }
+
+    /**
+     * @group anon
+     * @group show
+     */
+    public function testAnonShow() : void {
+        $crawler = $this->client->request('GET', '/monarch/1');
+        $this->assertSame(self::ANON_RESPONSE_CODE, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(0, $crawler->selectLink('Edit')->count());
+    }
+
+    /**
+     * @group user
+     * @group show
+     */
+    public function testUserShow() : void {
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/1');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(0, $crawler->selectLink('Edit')->count());
+    }
+
+    /**
+     * @group admin
+     * @group show
+     */
+    public function testAdminShow() : void {
+        $this->login('user.admin');
+        $crawler = $this->client->request('GET', '/monarch/1');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(1, $crawler->selectLink('Edit')->count());
+    }
+
+    /**
+     * @group anon
+     * @group typeahead
+     */
+    public function testAnonTypeahead() : void {
+        $this->client->request('GET', '/monarch/typeahead?q=' . self::TYPEAHEAD_QUERY);
+        $response = $this->client->getResponse();
+        $this->assertSame(self::ANON_RESPONSE_CODE, $this->client->getResponse()->getStatusCode());
+        if (self::ANON_RESPONSE_CODE === Response::HTTP_FOUND) {
+            // If authentication is required stop here.
+            return;
+        }
+        $this->assertSame('application/json', $response->headers->get('content-type'));
+        $json = json_decode($response->getContent());
+        $this->assertCount(4, $json);
+    }
+
+    /**
+     * @group user
+     * @group typeahead
+     */
+    public function testUserTypeahead() : void {
+        $this->login('user.user');
+        $this->client->request('GET', '/monarch/typeahead?q=' . self::TYPEAHEAD_QUERY);
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('content-type'));
+        $json = json_decode($response->getContent());
+        $this->assertCount(4, $json);
+    }
+
+    /**
+     * @group admin
+     * @group typeahead
+     */
+    public function testAdminTypeahead() : void {
+        $this->login('user.admin');
+        $this->client->request('GET', '/monarch/typeahead?q=' . self::TYPEAHEAD_QUERY);
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('content-type'));
+        $json = json_decode($response->getContent());
+        $this->assertCount(4, $json);
+    }
+
+    public function testAnonSearch() : void {
+        $repo = $this->createMock(MonarchRepository::class);
+        $repo->method('searchQuery')->willReturn([$this->getReference('monarch.1')]);
+        $this->client->disableReboot();
+        $this->client->getContainer()->set('test.' . MonarchRepository::class, $repo);
+
+        $crawler = $this->client->request('GET', '/monarch/search');
+        $this->assertSame(self::ANON_RESPONSE_CODE, $this->client->getResponse()->getStatusCode());
+        if (self::ANON_RESPONSE_CODE === Response::HTTP_FOUND) {
+            // If authentication is required stop here.
+            return;
+        }
+
+        $form = $crawler->selectButton('btn-search')->form([
+            'q' => 'monarch',
+        ]);
+
+        $responseCrawler = $this->client->submit($form);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testUserSearch() : void {
+        $repo = $this->createMock(MonarchRepository::class);
+        $repo->method('searchQuery')->willReturn([$this->getReference('monarch.1')]);
+        $this->client->disableReboot();
+        $this->client->getContainer()->set('test.' . MonarchRepository::class, $repo);
+
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/search');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $form = $crawler->selectButton('btn-search')->form([
+            'q' => 'monarch',
+        ]);
+
+        $responseCrawler = $this->client->submit($form);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function testAdminSearch() : void {
+        $repo = $this->createMock(MonarchRepository::class);
+        $repo->method('searchQuery')->willReturn([$this->getReference('monarch.1')]);
+        $this->client->disableReboot();
+        $this->client->getContainer()->set('test.' . MonarchRepository::class, $repo);
+
+        $this->login('user.admin');
+        $crawler = $this->client->request('GET', '/monarch/search');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $form = $crawler->selectButton('btn-search')->form([
+            'q' => 'monarch',
+        ]);
+
+        $responseCrawler = $this->client->submit($form);
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @group anon
+     * @group edit
+     */
+    public function testAnonEdit() : void {
+        $crawler = $this->client->request('GET', '/monarch/1/edit');
+        $this->assertSame(Response::HTTP_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+    }
+
+    /**
+     * @group user
+     * @group edit
+     */
+    public function testUserEdit() : void {
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/1/edit');
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @group admin
+     * @group edit
+     */
+    public function testAdminEdit() : void {
+        $this->login('user.admin');
+        $formCrawler = $this->client->request('GET', '/monarch/1/edit');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $form = $formCrawler->selectButton('Save')->form([
+            'monarch[label]' => 'Updated Label',
+            'monarch[description]' => 'Updated Description',
+        ]);
+
+        $this->client->submit($form);
+        $this->assertTrue($this->client->getResponse()->isRedirect('/monarch/1'));
+        $responseCrawler = $this->client->followRedirect();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Label")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("Updated Description")')->count());
+    }
+
+    /**
+     * @group anon
+     * @group new
+     */
+    public function testAnonNew() : void {
+        $crawler = $this->client->request('GET', '/monarch/new');
+        $this->assertSame(Response::HTTP_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+    }
+
+    /**
+     * @group anon
+     * @group new
+     */
+    public function testAnonNewPopup() : void {
+        $crawler = $this->client->request('GET', '/monarch/new_popup');
+        $this->assertSame(Response::HTTP_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+    }
+
+    /**
+     * @group user
+     * @group new
+     */
+    public function testUserNew() : void {
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/new');
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @group user
+     * @group new
+     */
+    public function testUserNewPopup() : void {
+        $this->login('user.user');
+        $crawler = $this->client->request('GET', '/monarch/new_popup');
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @group admin
+     * @group new
+     */
+    public function testAdminNew() : void {
+        $this->login('user.admin');
+        $formCrawler = $this->client->request('GET', '/monarch/new');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $form = $formCrawler->selectButton('Save')->form([
+            'monarch[label]' => 'New Label',
+            'monarch[description]' => 'New Description',
+        ]);
+
+        $this->client->submit($form);
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+        $responseCrawler = $this->client->followRedirect();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Label")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Description")')->count());
+    }
+
+    /**
+     * @group admin
+     * @group new
+     */
+    public function testAdminNewPopup() : void {
+        $this->login('user.admin');
+        $formCrawler = $this->client->request('GET', '/monarch/new_popup');
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $form = $formCrawler->selectButton('Save')->form([
+            'monarch[label]' => 'New Label',
+            'monarch[description]' => 'New Description',
+        ]);
+
+        $this->client->submit($form);
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+        $responseCrawler = $this->client->followRedirect();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Label")')->count());
+        $this->assertSame(1, $responseCrawler->filter('td:contains("New Description")')->count());
+    }
+
+    /**
+     * @group admin
+     * @group delete
+     */
+    public function testAdminDelete() : void {
+        $repo = self::$container->get(MonarchRepository::class);
+        $preCount = count($repo->findAll());
+
+        $this->login('user.admin');
+        $crawler = $this->client->request('GET', '/monarch/1');
+        $form = $crawler->selectButton('Delete')->form();
+        $this->client->submit($form);
+
+        $this->assertSame(Response::HTTP_FOUND, $this->client->getResponse()->getStatusCode());
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+        $responseCrawler = $this->client->followRedirect();
+        $this->assertSame(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+
+        $this->entityManager->clear();
+        $postCount = count($repo->findAll());
+        $this->assertSame($preCount - 1, $postCount);
+    }
+}


### PR DESCRIPTION
Change format of dates.

 fixes sfu-dhil/bep#84

Change wording of transaction location field description.

 fixes sfu-dhil/bep#85

Add page field to inventories.

 fixes sfu-dhil/bep#86

Add monarchs to inventory and transaction records.

 fixes sfu-dhil/bep#87

adjust wording in book form

 fixes sfu-dhil/bep#88

Make book typeahead search title and variant titles

Also sets a minimum length of three characters for the search, so that 
unrelated titles aren't fetched by matching the array serialization. Adds 
the variant titles to the result display in the book, transaction, and 
inventory forms.

 fixes sfu-dhil/bep#90

Rename publisher to imprint

Also adds variant imprint as a searchable field.

 fixes sfu-dhil/bep#91