### PR TITLE
Fix a bunch of old issues.

### DIFF
--- a/migrations/2022/02/Version20220202183839.php
+++ b/migrations/2022/02/Version20220202183839.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220202183839 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book ADD monarch_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE book ADD CONSTRAINT FK_CBE5A33153033E82 FOREIGN KEY (monarch_id) REFERENCES monarch (id)');
+        $this->addSql('CREATE INDEX IDX_CBE5A33153033E82 ON book (monarch_id)');
+        $this->addSql('ALTER TABLE injunction CHANGE variant_titles variant_titles LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book DROP FOREIGN KEY FK_CBE5A33153033E82');
+        $this->addSql('DROP INDEX IDX_CBE5A33153033E82 ON book');
+        $this->addSql('ALTER TABLE book DROP monarch_id');
+        $this->addSql('ALTER TABLE injunction CHANGE variant_titles variant_titles LONGTEXT CHARACTER SET utf8mb4 DEFAULT \'a:0:{}\' NOT NULL COLLATE `utf8mb4_unicode_ci` COMMENT \'(DC2Type:array)\'');
+    }
+}

--- a/migrations/2022/02/Version20220202184642.php
+++ b/migrations/2022/02/Version20220202184642.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220202184642 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE injunction ADD monarch_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE injunction ADD CONSTRAINT FK_A2FAC1E153033E82 FOREIGN KEY (monarch_id) REFERENCES monarch (id)');
+        $this->addSql('CREATE INDEX IDX_A2FAC1E153033E82 ON injunction (monarch_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE injunction DROP FOREIGN KEY FK_A2FAC1E153033E82');
+        $this->addSql('DROP INDEX IDX_A2FAC1E153033E82 ON injunction');
+        $this->addSql('ALTER TABLE injunction DROP monarch_id');
+    }
+}

--- a/migrations/2022/02/Version20220202191412.php
+++ b/migrations/2022/02/Version20220202191412.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220202191412 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book ADD estc VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book DROP estc');
+    }
+}

--- a/migrations/2022/02/Version20220202192426.php
+++ b/migrations/2022/02/Version20220202192426.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220202192426 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book ADD physical_description LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE book DROP physical_description');
+    }
+}

--- a/migrations/2022/02/Version20220202192656.php
+++ b/migrations/2022/02/Version20220202192656.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220202192656 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE injunction ADD physical_description LONGTEXT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE injunction DROP physical_description');
+    }
+}

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -86,6 +86,13 @@ class Book extends AbstractEntity implements LinkableInterface {
     private $format;
 
     /**
+     * @var Monarch
+     * @ORM\ManyToOne(targetEntity="Monarch", inversedBy="books")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $monarch;
+
+    /**
      * @var Collection|Transaction[]
      * @ORM\ManyToMany(targetEntity="App\Entity\Transaction", mappedBy="books")
      */
@@ -304,6 +311,18 @@ class Book extends AbstractEntity implements LinkableInterface {
 
     public function setVariantImprint(?string $variantImprint) : self {
         $this->variantImprint = $variantImprint;
+
+        return $this;
+    }
+
+    public function getMonarch(): ?Monarch
+    {
+        return $this->monarch;
+    }
+
+    public function setMonarch(?Monarch $monarch): self
+    {
+        $this->monarch = $monarch;
 
         return $this;
     }

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -69,6 +69,12 @@ class Book extends AbstractEntity implements LinkableInterface {
 
     /**
      * @var string
+     * @ORM\Column(type="string", nullable=true)
+     */
+    private $estc;
+
+    /**
+     * @var string
      * @ORM\Column(type="string", length=12, nullable=true)
      */
     private $date;
@@ -323,6 +329,18 @@ class Book extends AbstractEntity implements LinkableInterface {
     public function setMonarch(?Monarch $monarch): self
     {
         $this->monarch = $monarch;
+
+        return $this;
+    }
+
+    public function getEstc(): ?string
+    {
+        return $this->estc;
+    }
+
+    public function setEstc(?string $estc): self
+    {
+        $this->estc = $estc;
 
         return $this;
     }

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -86,6 +86,12 @@ class Book extends AbstractEntity implements LinkableInterface {
     private $description;
 
     /**
+     * @var string
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $physicalDescription;
+
+    /**
      * @var Format
      * @ORM\ManyToOne(targetEntity="Format", inversedBy="books")
      */
@@ -341,6 +347,18 @@ class Book extends AbstractEntity implements LinkableInterface {
     public function setEstc(?string $estc): self
     {
         $this->estc = $estc;
+
+        return $this;
+    }
+
+    public function getPhysicalDescription(): ?string
+    {
+        return $this->physicalDescription;
+    }
+
+    public function setPhysicalDescription(?string $physicalDescription): self
+    {
+        $this->physicalDescription = $physicalDescription;
 
         return $this;
     }

--- a/src/Entity/Injunction.php
+++ b/src/Entity/Injunction.php
@@ -76,6 +76,12 @@ class Injunction extends AbstractEntity implements LinkableInterface {
      * @var string
      * @ORM\Column(type="text")
      */
+    private $physicalDescription;
+
+    /**
+     * @var string
+     * @ORM\Column(type="text")
+     */
     private $description;
 
     /**
@@ -236,6 +242,18 @@ class Injunction extends AbstractEntity implements LinkableInterface {
     public function setMonarch(?Monarch $monarch): self
     {
         $this->monarch = $monarch;
+
+        return $this;
+    }
+
+    public function getPhysicalDescription(): ?string
+    {
+        return $this->physicalDescription;
+    }
+
+    public function setPhysicalDescription(string $physicalDescription): self
+    {
+        $this->physicalDescription = $physicalDescription;
 
         return $this;
     }

--- a/src/Entity/Injunction.php
+++ b/src/Entity/Injunction.php
@@ -85,6 +85,13 @@ class Injunction extends AbstractEntity implements LinkableInterface {
     private $estc;
 
     /**
+     * @var Monarch
+     * @ORM\ManyToOne(targetEntity="Monarch", inversedBy="injunctions")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $monarch;
+
+    /**
      * @var Collection
      * @ORM\OneToMany(targetEntity="App\Entity\Transaction", mappedBy="injunction")
      */
@@ -217,6 +224,18 @@ class Injunction extends AbstractEntity implements LinkableInterface {
                 $transaction->setInjunction(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getMonarch(): ?Monarch
+    {
+        return $this->monarch;
+    }
+
+    public function setMonarch(?Monarch $monarch): self
+    {
+        $this->monarch = $monarch;
 
         return $this;
     }

--- a/src/Entity/Injunction.php
+++ b/src/Entity/Injunction.php
@@ -32,7 +32,7 @@ class Injunction extends AbstractEntity implements LinkableInterface {
 
     /**
      * @var string
-     * @ORM\Column(type="string")
+     * @ORM\Column(type="text")
      */
     private $title;
 

--- a/src/Entity/Monarch.php
+++ b/src/Entity/Monarch.php
@@ -32,10 +32,17 @@ class Monarch extends AbstractTerm {
      */
     private $inventories;
 
+    /**
+     * @var Collection
+     * @ORM\OneToMany(targetEntity="Book", mappedBy="monarch")
+     */
+    private $books;
+
     public function __construct() {
         parent::__construct();
         $this->transactions = new ArrayCollection();
         $this->inventories = new ArrayCollection();
+        $this->books = new ArrayCollection();
     }
 
     /**
@@ -86,6 +93,36 @@ class Monarch extends AbstractTerm {
             // set the owning side to null (unless already changed)
             if ($inventory->getMonarch() === $this) {
                 $inventory->setMonarch(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Book[]
+     */
+    public function getBooks(): Collection
+    {
+        return $this->books;
+    }
+
+    public function addBook(Book $book): self
+    {
+        if (!$this->books->contains($book)) {
+            $this->books[] = $book;
+            $book->setMonarch($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBook(Book $book): self
+    {
+        if ($this->books->removeElement($book)) {
+            // set the owning side to null (unless already changed)
+            if ($book->getMonarch() === $this) {
+                $book->setMonarch(null);
             }
         }
 

--- a/src/Entity/Monarch.php
+++ b/src/Entity/Monarch.php
@@ -28,6 +28,12 @@ class Monarch extends AbstractTerm {
 
     /**
      * @var Collection
+     * @ORM\OneToMany(targetEntity="Injunction", mappedBy="monarch")
+     */
+    private $injunctions;
+
+    /**
+     * @var Collection
      * @ORM\OneToMany(targetEntity="Inventory", mappedBy="monarch")
      */
     private $inventories;
@@ -41,6 +47,7 @@ class Monarch extends AbstractTerm {
     public function __construct() {
         parent::__construct();
         $this->transactions = new ArrayCollection();
+        $this->injunctions = new ArrayCollection();
         $this->inventories = new ArrayCollection();
         $this->books = new ArrayCollection();
     }
@@ -123,6 +130,36 @@ class Monarch extends AbstractTerm {
             // set the owning side to null (unless already changed)
             if ($book->getMonarch() === $this) {
                 $book->setMonarch(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Injunction[]
+     */
+    public function getInjunctions(): Collection
+    {
+        return $this->injunctions;
+    }
+
+    public function addInjunction(Injunction $injunction): self
+    {
+        if (!$this->injunctions->contains($injunction)) {
+            $this->injunctions[] = $injunction;
+            $injunction->setMonarch($this);
+        }
+
+        return $this;
+    }
+
+    public function removeInjunction(Injunction $injunction): self
+    {
+        if ($this->injunctions->removeElement($injunction)) {
+            // set the owning side to null (unless already changed)
+            if ($injunction->getMonarch() === $this) {
+                $injunction->setMonarch(null);
             }
         }
 

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -115,6 +115,15 @@ class BookType extends AbstractType {
             ],
         ]);
 
+        $builder->add('physicalDescription', TextareaType::class, [
+            'label' => 'Physical Description',
+            'required' => false,
+            'attr' => [
+                'help_block' => 'Public description of the physicality of the item.',
+                'class' => 'tinymce',
+            ],
+        ]);
+
         $builder->add('description', TextareaType::class, [
             'label' => 'Description',
             'required' => false,

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -12,6 +12,7 @@ namespace App\Form;
 
 use App\Entity\Book;
 use App\Entity\Format;
+use App\Entity\Monarch;
 use App\Form\Partial\NotesType;
 use Nines\MediaBundle\Form\LinkableType;
 use Nines\MediaBundle\Form\Mapper\LinkableMapper;
@@ -93,6 +94,19 @@ class BookType extends AbstractType {
                 'help_block' => '',
             ],
         ]);
+
+        $builder->add('monarch', Select2EntityType::class, [
+            'label' => 'Monarch',
+            'required' => false,
+            'class' => Monarch::class,
+            'remote_route' => 'monarch_typeahead',
+            'attr' => [
+                'help_block' => '',
+                'add_path' => 'monarch_new_popup',
+                'add_label' => 'Add Monarch',
+            ],
+        ]);
+
         $builder->add('description', TextareaType::class, [
             'label' => 'Description',
             'required' => false,

--- a/src/Form/BookType.php
+++ b/src/Form/BookType.php
@@ -95,6 +95,14 @@ class BookType extends AbstractType {
             ],
         ]);
 
+        $builder->add('estc', TextType::class, [
+            'label' => 'Estc',
+            'required' => false,
+            'attr' => [
+                'help_block' => '',
+            ],
+        ]);
+
         $builder->add('monarch', Select2EntityType::class, [
             'label' => 'Monarch',
             'required' => false,

--- a/src/Form/InjunctionType.php
+++ b/src/Form/InjunctionType.php
@@ -12,6 +12,7 @@ namespace App\Form;
 
 use App\Entity\Injunction;
 
+use App\Entity\Monarch;
 use Nines\MediaBundle\Form\LinkableType;
 use Nines\MediaBundle\Form\Mapper\LinkableMapper;
 use Symfony\Component\Form\AbstractType;
@@ -20,6 +21,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Tetranz\Select2EntityBundle\Form\Type\Select2EntityType;
 
 /**
  * Injunction form.
@@ -98,6 +100,17 @@ class InjunctionType extends AbstractType {
             'attr' => [
                 'help_block' => 'Public description of the item.',
                 'class' => 'tinymce',
+            ],
+        ]);
+        $builder->add('monarch', Select2EntityType::class, [
+            'label' => 'Monarch',
+            'required' => false,
+            'class' => Monarch::class,
+            'remote_route' => 'monarch_typeahead',
+            'attr' => [
+                'help_block' => '',
+                'add_path' => 'monarch_new_popup',
+                'add_label' => 'Add Monarch',
             ],
         ]);
         $builder->add('estc', TextType::class, [

--- a/src/Form/InjunctionType.php
+++ b/src/Form/InjunctionType.php
@@ -94,6 +94,15 @@ class InjunctionType extends AbstractType {
                 'help_block' => '',
             ],
         ]);
+        $builder->add('physicalDescription', TextareaType::class, [
+            'label' => 'Physical Description',
+            'required' => false,
+            'attr' => [
+                'help_block' => 'Public description of the physicality of the item.',
+                'class' => 'tinymce',
+            ],
+        ]);
+
         $builder->add('description', TextareaType::class, [
             'label' => 'Description',
             'required' => true,

--- a/templates/book/partial/detail.html.twig
+++ b/templates/book/partial/detail.html.twig
@@ -59,6 +59,12 @@
             </td>
         </tr>
         <tr>
+            <th>Physical Description</th>
+            <td>
+                {{ book.physicalDescription|raw }}
+            </td>
+        </tr>
+        <tr>
             <th>Description</th>
             <td>
                 {{ book.description|raw }}

--- a/templates/book/partial/detail.html.twig
+++ b/templates/book/partial/detail.html.twig
@@ -45,6 +45,14 @@
             </td>
         </tr>
         <tr>
+            <th>Monarch</th>
+            <td>
+                {% if book.monarch %}
+                    <a href='{{ path('monarch_show', {'id': book.monarch.id}) }}'>{{ book.monarch }}</a>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
             <th>Description</th>
             <td>
                 {{ book.description|raw }}

--- a/templates/book/partial/detail.html.twig
+++ b/templates/book/partial/detail.html.twig
@@ -45,6 +45,12 @@
             </td>
         </tr>
         <tr>
+            <th>Estc</th>
+            <td>
+                {{ book.estc }}
+            </td>
+        </tr>
+        <tr>
             <th>Monarch</th>
             <td>
                 {% if book.monarch %}

--- a/templates/book/partial/table.html.twig
+++ b/templates/book/partial/table.html.twig
@@ -6,15 +6,21 @@
             <th>Author</th>
             <th>Imprint</th>
             <th>Date</th>
+            <th>Monarch</th>
         </tr>
     </thead>
     <tbody>
         {% for book in books %}
             <tr>
                 <td>
-                    <a href="{{ path('book_show', { 'id': book.id }) }}">
-                        {{ book.title }}
-                    </a>
+                    <p>
+                        <a href="{{ path('book_show', { 'id': book.id }) }}">
+                            {{ book.title }}
+                        </a>
+                    </p>
+                    {% if book.estc %}
+                        <p>ESTC: {{ book.estc }}</p>
+                    {% endif %}
                 </td>
                 <td>
                     {{ book.uniformTitle }}
@@ -30,6 +36,9 @@
 
                 <td>
                     {{ book.date }}
+                </td>
+                <td>
+                    {{ book.monarch }}
                 </td>
             </tr>
         {% endfor %}

--- a/templates/injunction/partial/detail.html.twig
+++ b/templates/injunction/partial/detail.html.twig
@@ -54,6 +54,14 @@
                 {{ injunction.estc }}
             </td>
         </tr>
+        <tr>
+            <th>Monarch</th>
+            <td>
+                {% if injunction.monarch %}
+                    <a href='{{ path('monarch_show', {'id': injunction.monarch.id}) }}'>{{ book.monarch }}</a>
+                {% endif %}
+            </td>
+        </tr>
 
         <tr>
             <th>Transaction</th>

--- a/templates/injunction/partial/detail.html.twig
+++ b/templates/injunction/partial/detail.html.twig
@@ -43,6 +43,12 @@
             </td>
         </tr>
         <tr>
+            <th>Physical Description</th>
+            <td>
+                {{ injunction.physicalDescription|raw }}
+            </td>
+        </tr>
+        <tr>
             <th>Description</th>
             <td>
                 {{ injunction.description|raw }}

--- a/templates/injunction/partial/table.html.twig
+++ b/templates/injunction/partial/table.html.twig
@@ -3,6 +3,7 @@
         <tr>
             <th>Title</th>
             <th>Date</th>
+            <th>Monarch</th>
             <th>Description</th>
         </tr>
     </thead>
@@ -10,12 +11,22 @@
         {% for injunction in injunctions %}
             <tr>
                 <td>
-                    <a href="{{ path('injunction_show', { 'id': injunction.id }) }}">
-                        {{ injunction.title }}
-                    </a>
+                    <p>
+                        <a href="{{ path('injunction_show', { 'id': injunction.id }) }}">
+                            {{ injunction.title }}
+                        </a>
+                    </p>
+                    {% if injunction.estc %}
+                        <p>ESTC: {{ injunction.estc }}</p>
+                    {% endif %}
                 </td>
                 <td>
                     {{ injunction.date }}
+                </td>
+                <td>
+                    {% if injunction.monarch %}
+                        <a href='{{ path('monarch_show', {'id': injunction.monarch.id}) }}'>{{ injunction.monarch }}</a>
+                    {% endif %}
                 </td>
                 <td>
                     {{ injunction.description|raw }}

--- a/templates/inventory/partial/detail.html.twig
+++ b/templates/inventory/partial/detail.html.twig
@@ -25,6 +25,14 @@
             <th>Date</th>
             <td>{% include 'partial/long-date.html.twig' with {'entity': inventory} %}</td>
         </tr>
+        <tr>
+            <th>Monarch</th>
+            <td>
+                {% if inventory.monarch %}
+                    <a href='{{ path('monarch_show', {'id': inventory.monarch.id}) }}'>{{ inventory.monarch }}</a>
+                {% endif %}
+            </td>
+        </tr>
 
         <tr>
             <th>Source</th>

--- a/templates/inventory/partial/table.html.twig
+++ b/templates/inventory/partial/table.html.twig
@@ -24,6 +24,7 @@
                     <a href='{{ path('source_show', {'id': inventory.source.id}) }}'>
                         {{ inventory.source }}
                     </a>
+                    {{ inventory.pageNumber }}
                 </td>
                 <td>
                     {{ inventory.books|length }}

--- a/templates/monarch/partial/detail.html.twig
+++ b/templates/monarch/partial/detail.html.twig
@@ -32,6 +32,22 @@
                 {% endif %}
             </td>
         </tr>
+        <tr>
+            <th>Books</th>
+            <td>
+                {% if monarch.books|length > 0 %}
+                    <ul>
+                        {% for book in monarch.books %}
+                            <li>
+                                <a href='{{ path("book_show", {"id":book.id }) }}'>
+                                    {{ book }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </td>
+        </tr>
     {% endblock %}
 {% endembed %}
 

--- a/templates/monarch/partial/detail.html.twig
+++ b/templates/monarch/partial/detail.html.twig
@@ -17,6 +17,22 @@
             </td>
         </tr>
         <tr>
+            <th>Injunctions</th>
+            <td>
+                {% if monarch.injunctions|length > 0 %}
+                    <ul>
+                        {% for injunction in monarch.injunctions %}
+                            <li>
+                                <a href='{{ path("injunction_show", {"id":injunction.id }) }}'>
+                                    {{ injunction }}
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
             <th>Transactions</th>
             <td>
                 {% if monarch.transactions|length > 0 %}

--- a/templates/transaction/partial/detail.html.twig
+++ b/templates/transaction/partial/detail.html.twig
@@ -39,6 +39,14 @@
             </td>
         </tr>
         <tr>
+            <th>Monarch</th>
+            <td>
+                {% if transaction.monarch %}
+                    <a href='{{ path('monarch_show', {'id': transaction.monarch.id}) }}'>{{ transaction.monarch }}</a>
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
             <th>Transcription</th>
             <td>
                 {{ transaction.transcription|raw }}

--- a/templates/transaction/partial/table.html.twig
+++ b/templates/transaction/partial/table.html.twig
@@ -2,7 +2,7 @@
     <thead>
         <tr>
             <th>ID</th>
-            <th>Date</th>
+            <th>Date &amp; Source</th>
             <th>Value</th>
             <th>Books</th>
             <th>Parish</th>
@@ -19,11 +19,19 @@
                     </a>
                 </td>
                 <td>
-                    <a href="{{ path('transaction_show', { 'id': transaction.id }) }}">
+                    <p>
+                        <a href="{{ path('transaction_show', { 'id': transaction.id }) }}">
                         {% include 'partial/short-date.html.twig' with {'entity': transaction} %}
-                    </a>
+                        </a>
+                    </p>
+                    <p>
+                        {% if transaction.source %}
+                            <a href='{{ path('source_show', {'id': transaction.source.id}) }}'>{{ transaction.source }}</a>
+                            {% if transaction.page %}<br>{{ transaction.page }}{% endif %}
+                        {% endif %}
+                    </p>
                 </td>
-                <td>
+                <td style='white-space: nowrap'>
                     {{ transaction.value(true) }}
                 </td>
 


### PR DESCRIPTION
Add source and page info to transaction list

Note that private notes is too large to be displayed in the table.

- fixes sfu-dhil/bep#117

Add page number to inventory list

Note that the transcription and modern english fields are too large
to fit in the table.

- fixes sfu-dhil/bep#118

Add more information to the book list

- fixes sfu-dhil/bep#119

Remove character limit in injunction titles

- fixes sfu-dhil/bep#122

Add physical description field to injunctions

- fixes sfu-dhil/bep#123

Add physical description field to book records

- fixes sfu-dhil/bep#133

Add ESTC field to book records.

- fixes sfu-dhil/bep#116
- fixes sfu-dhil/bep#132

Add Monarch and ESTC ID to injunction list page

- fixes sfu-dhil/bep#120

Add monarch field to transaction details.

Note that page is already included in the source field.

- fixes sfu-dhil/bep#114

Add monarch field to inventory details page

- fixes sfu-dhil/bep#115

Add monarch field to injunctions

- fixes sfu-dhil/bep#112 fixes sfu-dhil/bep#126

Add monarch field to book records

- fixes sfu-dhil/bep#134 fixes sfu-dhil/bep#113